### PR TITLE
fix: LANG variable in .env being overriden by common shell variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # VARIABLE=value #comment
-LANG=en
+LANGUAGE=en
 BEAM_SIZE=5
 MODEL=large-v2
 PROMPT=""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       - SYCL_CACHE_PERSISTENT=1
       - SYCL_CACHE_DIR=/models/sycl_cache
       - SYCL_DEVICE_ALLOWLIST=BackendName:level_zero
-    command: build/bin/whisper-server -l ${LANG} -bs ${BEAM_SIZE} -m
+    command: build/bin/whisper-server -l ${LANGUAGE} -bs ${BEAM_SIZE} -m
       /models/ggml-$MODEL.bin --host 0.0.0.0 --port 8910 --suppress-nst --prompt
       "$PROMPT"
   wyoming-api:


### PR DESCRIPTION
This is a workaround for issue #2. Feel free to provide another solution or simply reject this PR, I just thought I provide this solution that worked for me.